### PR TITLE
Fix URI encoding of special characters by replacing encodeURI with encodeURIComponent

### DIFF
--- a/index.js
+++ b/index.js
@@ -99,7 +99,7 @@ async function getAllItemNames() {
 async function fetchPrice(name) {
     return new Promise((resolve, reject) => {
         community.request.get(
-            `${MARKET_BASE_URL}/pricehistory/?appid=730&market_hash_name=${encodeURI(
+            `${MARKET_BASE_URL}/pricehistory/?appid=730&market_hash_name=${encodeURIComponent(
                 name
             )}`,
             (err, res) => {


### PR DESCRIPTION
Items with names like "Dreams & Nightmares Case" and "Copenhagen 2024 Viewer Pass + 3 Souvenir Tokens" didn't get encoded properly with `encodeURI`, making the prices `null`, since `encodeURI` is used for encoding full URLs.