### PR TITLE
Add support for fetching keychains prices

### DIFF
--- a/index.js
+++ b/index.js
@@ -133,6 +133,9 @@ async function getAllItemNames() {
         fetch(`${ITEMS_API_BASE_URL}/collectibles.json`)
             .then((res) => res.json())
             .then((res) => res.map((item) => item.market_hash_name)),
+        fetch(`${ITEMS_API_BASE_URL}/keychains.json`)
+            .then((res) => res.json())
+            .then((res) => res.map((item) => item.market_hash_name)),
     ]).then((results) => results.flat().filter(Boolean));
 }
 


### PR DESCRIPTION
Currently, no keychains are for sale due to the 7-day trade/market cooldown, but this should work once someone lists them.